### PR TITLE
Adds detection of ES2015's new Object functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ if (detect.all('class', 'spread', 'let', 'arrowFunction')){
     * [.let()](#module_feature-detect-es6.let) ⇒ <code>boolean</code>
     * [.const()](#module_feature-detect-es6.const) ⇒ <code>boolean</code>
     * [.newArrayFeatures()](#module_feature-detect-es6.newArrayFeatures) ⇒ <code>boolean</code>
+    * [.newObjectFeatures()](#module_feature-detect-es6.newObjectFeatures) ⇒ <code>boolean</code>
     * [.collections()](#module_feature-detect-es6.collections) ⇒ <code>boolean</code>
     * [.generators()](#module_feature-detect-es6.generators) ⇒ <code>boolean</code>
     * [.promises()](#module_feature-detect-es6.promises) ⇒ <code>boolean</code>
@@ -64,6 +65,12 @@ Returns true if the `const` statement is available.
 
 ### detect.newArrayFeatures() ⇒ <code>boolean</code>
 Returns true if the [new Array features](http://exploringjs.com/es6/ch_arrays.html) are available (exluding `Array.prototype.values` which has zero support anywhere).
+
+**Kind**: static method of <code>[feature-detect-es6](#module_feature-detect-es6)</code>  
+<a name="module_feature-detect-es6.newObjectFeatures"></a>
+
+### detect.newObjectFeatures() ⇒ <code>boolean</code>
+Returns true if the new functions of Object are available.
 
 **Kind**: static method of <code>[feature-detect-es6](#module_feature-detect-es6)</code>  
 <a name="module_feature-detect-es6.collections"></a>

--- a/lib/feature-detect-es6.js
+++ b/lib/feature-detect-es6.js
@@ -69,6 +69,17 @@ exports.newArrayFeatures = function () {
 }
 
 /**
+ * Returns true if the new functions of Object are available.
+ *
+ * @returns {boolean}
+ */
+exports.newObjectFeatures = function() {
+  return typeof Object.assign !== 'undefined' && 
+    typeof Object.setPrototypeOf !== 'undefined' &&
+    typeof Object.getOwnPropertySymbols !== 'undefined';
+}
+
+/**
  * Returns true if `Map`, `WeakMap`, `Set` and `WeakSet` are available.
  *
  * @returns {boolean}

--- a/lib/feature-detect-es6.js
+++ b/lib/feature-detect-es6.js
@@ -76,7 +76,8 @@ exports.newArrayFeatures = function () {
 exports.newObjectFeatures = function() {
   return typeof Object.assign !== 'undefined' && 
     typeof Object.setPrototypeOf !== 'undefined' &&
-    typeof Object.getOwnPropertySymbols !== 'undefined';
+    typeof Object.getOwnPropertySymbols !== 'undefined' &&
+    typeof Object.is !== 'undefined';
 }
 
 /**

--- a/test/iojs.js
+++ b/test/iojs.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), false)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), true)
   t.end()

--- a/test/v0.10.js
+++ b/test/v0.10.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), false)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), false)
   t.end()

--- a/test/v0.12.js
+++ b/test/v0.12.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), false)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), true)
   t.end()

--- a/test/v4.js
+++ b/test/v4.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), true)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), true)
   t.end()

--- a/test/v5.js
+++ b/test/v5.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), true)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), true)
   t.end()

--- a/test/v6.js
+++ b/test/v6.js
@@ -26,6 +26,11 @@ test('.newArrayFeatures()', function (t) {
   t.end()
 })
 
+test('.newObjectFeatures()', function (t) {
+  t.strictEqual(detect.newObjectFeatures(), true)
+  t.end()
+})
+
 test('.collections()', function (t) {
   t.strictEqual(detect.collections(), true)
   t.end()


### PR DESCRIPTION
Hi there,

I'm using this library for a while, and recently I've noticed [this issue](https://github.com/75lb/feature-detect-es6/issues/1), and I thought it would be a good idea to add this feature.

I'm testing for the existence of: `assign`, `setPrototypeOf` `getOwnPropertySymbols` in `Object`.
I also included the tests.

LMK if you think things should be different. 

Eliran 